### PR TITLE
secure supabase env config and document setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,25 @@
 # calculadoraproteemvt
 
 Proyecto de calculadora nutricional listo para deploy en Vercel.
+
+## Configuración de Supabase
+
+Las credenciales de Supabase ya no están incrustadas en el código. Se leen
+desde variables de entorno definidas en la plataforma de despliegue:
+
+1. Define los secretos en Vercel:
+
+   ```bash
+   vercel env add SUPABASE_URL
+   vercel env add SUPABASE_ANON_KEY
+   ```
+
+2. Cuando se despliegue, `api/env.js` expondrá estas variables al cliente y
+   `index.html` las utilizará para inicializar `@supabase/supabase-js`.
+
+Esta estrategia evita exponer claves sensibles en el repositorio.
+
+## Dependencias externas
+
+El paquete `@supabase/supabase-js` se sirve desde un CDN con una versión
+fijada y atributos de integridad para mayor seguridad.

--- a/api/env.js
+++ b/api/env.js
@@ -1,0 +1,7 @@
+export default function handler(req, res) {
+  res.setHeader('Content-Type', 'application/javascript');
+  res.send(`window.env = {
+    SUPABASE_URL: "${process.env.SUPABASE_URL}",
+    SUPABASE_ANON_KEY: "${process.env.SUPABASE_ANON_KEY}"
+  };`);
+}

--- a/index.html
+++ b/index.html
@@ -390,13 +390,16 @@
 
   <div id="toast" class="toast" role="status" aria-live="polite"></div>
 
-  <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.43.1/dist/umd/supabase.min.js"
+    integrity="sha384-OLBgp1GsljhM2TJ+sbHjaiH9txEUvgdDTAzHv2P24donTt6/529l+9Ua0vFImLlb"
+    crossorigin="anonymous"></script>
+  <script src="/api/env.js"></script>
   <script>
   const { createClient } = supabase;
-  const SUPABASE_URL = "https://dnygudxhimjksxedzckl.supabase.co";
-  const SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImRueWd1ZHhoaW1qa3N4ZWR6Y2tsIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTY3NzA5NTEsImV4cCI6MjA3MjM0Njk1MX0.VysJaMOWnPpkg0ty4F68C5G_fI7gw8iabDL4SE_mzWI";
+  const SUPABASE_URL = window.env.SUPABASE_URL;
+  const SUPABASE_ANON_KEY = window.env.SUPABASE_ANON_KEY;
   const sb = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
-
+  
   const $ = (id)=>document.getElementById(id);
   const show = (id)=>$(id).classList.remove('hide');
   const hide = (id)=>$(id).classList.add('hide');

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,9 @@
 {
   "version": 2,
   "name": "calculadoraproteemvt",
-  "builds": [{"src": "index.html", "use": "@vercel/static"}]
+  "builds": [{"src": "index.html", "use": "@vercel/static"}],
+  "env": {
+    "SUPABASE_URL": "@supabase-url",
+    "SUPABASE_ANON_KEY": "@supabase-anon-key"
+  }
 }


### PR DESCRIPTION
## Summary
- load Supabase config from environment via serverless endpoint
- pin `@supabase/supabase-js` to a specific version with SRI
- document env-based Supabase setup to avoid key exposure

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bfc3f88d58832695d81cae8dc19dac