### PR TITLE
Restore previous visual identity and fix tests

### DIFF
--- a/escapeHtml.test.js
+++ b/escapeHtml.test.js
@@ -1,4 +1,5 @@
-const assert = require('assert');
+import test from 'node:test';
+import assert from 'node:assert/strict';
 
 function escapeHtml(s) {
   return (s || '').replace(/[&<>"'\/]/g, c => ({
@@ -11,12 +12,12 @@ function escapeHtml(s) {
   }[c]));
 }
 
-assert.strictEqual(escapeHtml('&'), '&amp;');
-assert.strictEqual(escapeHtml('<'), '&lt;');
-assert.strictEqual(escapeHtml('>'), '&gt;');
-assert.strictEqual(escapeHtml('"'), '&quot;');
-assert.strictEqual(escapeHtml("'"), '&#x27;');
-assert.strictEqual(escapeHtml('/'), '&#x2F;');
-assert.strictEqual(escapeHtml("&<>\"'/"), '&amp;&lt;&gt;&quot;&#x27;&#x2F;');
-
-console.log('escapeHtml tests passed');
+test('escapeHtml escapes special characters', () => {
+  assert.strictEqual(escapeHtml('&'), '&amp;');
+  assert.strictEqual(escapeHtml('<'), '&lt;');
+  assert.strictEqual(escapeHtml('>'), '&gt;');
+  assert.strictEqual(escapeHtml('"'), '&quot;');
+  assert.strictEqual(escapeHtml("'"), '&#x27;');
+  assert.strictEqual(escapeHtml('/'), '&#x2F;');
+  assert.strictEqual(escapeHtml("&<>\"'/"), '&amp;&lt;&gt;&quot;&#x27;&#x2F;');
+});

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@ codex/refactorizar-logica-en-modulos
   <title>ProteeMVT — Calculadora & Registro de Macros</title>
   <meta name="description" content="Calcula tus macros, registra tus comidas y mide tu avance con una experiencia rápida y confiable." />
   <meta name="color-scheme" content="light" />
-  <meta name="theme-color" content="#10b981" />
+  <meta name="theme-color" content="#ffffff" />
   <meta property="og:title" content="ProteeMVT — Calculadora & Registro de Macros" />
   <meta property="og:description" content="Calcula tus macros, guarda tus metas y registra tus comidas con una experiencia rápida, accesible y confiable." />
   <meta property="og:type" content="website" />
@@ -25,7 +25,7 @@ codex/refactorizar-logica-en-modulos
   <meta property="og:locale" content="es_ES" />
   <meta name="twitter:card" content="summary_large_image" />
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://unpkg.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; connect-src 'self' https://dnygudxhimjksxedzckl.supabase.co; font-src https://fonts.gstatic.com; img-src 'self' data:; object-src 'none'">
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Poppins:wght@600;700;800&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&family=Nunito:wght@400;700;900&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="/styles.css">
   </head>
 <body>

--- a/styles.css
+++ b/styles.css
@@ -1,32 +1,104 @@
-:root{ --emerald:#10b981; --emerald-2:#0ea77a; --ink:#0b1a20; --paper:#f8fffb; --glass:#ffffff; --stroke: rgba(12,130,94,.14); --ring: rgba(16,185,129,.24); --shadow: 0 14px 34px rgba(5,28,22,.08), 0 4px 14px rgba(5,28,22,.06); --radius-xl: 22px; --danger:#d14343; --muted:#4b6b64; }
-*,*::before,*::after{ box-sizing:border-box } html,body{ margin:0; padding:0 }
-body{ font-family:'Inter',system-ui,-apple-system,Segoe UI,Roboto,Arial,Helvetica,sans-serif; color:var(--ink); background:var(--paper); min-height:100dvh; -webkit-font-smoothing:antialiased; -moz-osx-font-smoothing:grayscale; }
-.wrap{ max-width:1200px; margin:0 auto; padding:0 20px 72px }
-.hide{ display:none !important } .row{ display:flex; gap:10px; flex-wrap:wrap }
-.stack-8{ display:grid; gap:8px } .stack-10{ display:grid; gap:10px } .stack-12{ display:grid; gap:12px } .stack-16{ display:grid; gap:16px }
-.muted{ color:var(--muted); font-size:13px } .center{text-align:center} .right{text-align:right}
-.card{ background:var(--glass); border:1px solid var(--stroke); border-radius:22px; box-shadow:var(--shadow); padding:18px }
-label{ font-weight:600; font-size:13px; display:inline-block; margin-bottom:6px; letter-spacing:.2px }
-input,select{ width:100%; padding:14px; border-radius:14px; border:1px solid #e5efea; background:#fff; font-size:16px; outline:none; transition:box-shadow .18s,border .18s }
-input:focus,select:focus{ border-color:var(--emerald); box-shadow:0 0 0 4px var(--ring) }
-input[type=number]{ -moz-appearance:textfield } input::-webkit-outer-spin-button,input::-webkit-inner-spin-button{ -webkit-appearance:none; margin:0 }
-.btn{ display:inline-flex; align-items:center; justify-content:center; gap:8px; padding:12px 16px; border-radius:999px; border:1px solid var(--stroke); background:#fff; color:#0f2a23; font-weight:800; cursor:pointer; transition:transform .06s }
-.btn:active{ transform:translateY(1px) } .btn[disabled]{ opacity:.6; cursor:not-allowed }
-.btn-primary{ background:linear-gradient(135deg,#16d39f,#0fb787); color:#04241b; border-color:transparent; box-shadow:0 12px 26px rgba(16,185,129,.26), inset 0 -2px 0 rgba(0,0,0,.06) }
-.btn-soft{ background:#f3fbf8; border-color:#e3f3ed }
-header#topbar{ position:sticky; top:0; z-index:30 }
-.tb{ max-width:1200px; margin:10px auto; padding:10px 16px; display:flex; align-items:center; justify-content:space-between; gap:12px; background:var(--glass); border:1px solid var(--stroke); border-radius:20px; box-shadow:var(--shadow) }
-.hero{ color:#0a2a22 } .hero-pad{ padding:clamp(28px,6vw,56px) 20px } .hero-grid{ display:grid; grid-template-columns:1fr; gap:20px } @media(min-width:980px){ .hero-grid{ grid-template-columns:1.2fr .8fr } }
-.display{ margin:8px 0 6px; line-height:1.02; font-weight:800; font-family:'Poppins','Inter',sans-serif; font-size:clamp(38px,7vw,72px); color:#0c3e33 }
-.lead{ margin:10px 0 0; max-width:820px; font-size:clamp(16px,2.2vw,19px); color:#2f5b52 }
-nav.tabs{ display:flex; gap:8px; flex-wrap:wrap; margin:10px 0 18px }
-nav.tabs button{ border:none; background:#ecfbf6; color:#0b4d3f; padding:10px 16px; border-radius:999px; font-weight:800; cursor:pointer; box-shadow:inset 0 0 0 1px #d8efe8; font-family:'Poppins','Inter',sans-serif }
-nav.tabs button[aria-current=page]{ background:#0fb787; color:#04241b }
-.grid-2{ display:grid; gap:16px; grid-template-columns:1fr } .grid-3{ display:grid; gap:16px; grid-template-columns:1fr } @media(min-width:880px){ .grid-2{ grid-template-columns:1fr 1fr } .grid-3{ grid-template-columns:repeat(3,1fr) } }
-table{ width:100%; border-collapse:separate; border-spacing:0; background:#fff; border:1px solid #e6f1ec; border-radius:16px; overflow:hidden }
-th,td{ padding:12px 10px; text-align:left; border-bottom:1px solid #eef6f2 } th{ background:#f6fdfa; font-size:13px; color:#0a372d }
-.bar{ height:12px; border-radius:999px; background:#e9f6f0; overflow:hidden } .bar>span{ display:block; height:100%; width:0; background:linear-gradient(90deg,#10b981,#0ea77a) }
-.toast{ position:fixed; bottom:22px; right:22px; background:#05261f; color:#d9fff4; padding:12px 14px; border-radius:14px; box-shadow:var(--shadow); opacity:0; transform:translateY(8px); pointer-events:none; transition:.25s }
-.toast.show{ opacity:1; transform:translateY(0); pointer-events:auto }
-.modal{ position:fixed; inset:0; display:grid; place-items:center; background:rgba(2,16,13,.22) }
+    /* ========= Design System ========= */
+    :root{
+      --brand:#2e8b57;        /* Green */
+      --brand-2:#1f7246;      /* Darker */
+      --accent:#21b477;       /* Accent */
+      --ink:#102019;          /* Primary text */
+      --muted:#5b6f66;        /* Muted text */
+      --bg:#f7faf8;           /* App background */
+      --card:#ffffff;         /* Cards / surfaces */
+      --line:#e8efe9;         /* Hairline */
+      --ring:rgba(46,139,87,.18);
+      --shadow: 0 10px 25px rgba(16,32,25,.06), 0 2px 8px rgba(16,32,25,.04);
+      --radius: 16px;
+    }
+    *{box-sizing:border-box}
+    html,body{margin:0;padding:0}
+    body{
+      font-family:'Inter','Nunito',system-ui,-apple-system,Segoe UI,Roboto,Arial,Helvetica,sans-serif;
+      color:var(--ink);
+      background:
+        /* textura sutil con SVG embebido */
+        url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120' viewBox='0 0 120 120'%3E%3Cg fill='%23eaf4ef' fill-opacity='0.6'%3E%3Ccircle cx='2' cy='2' r='1'/%3E%3Ccircle cx='62' cy='42' r='1'/%3E%3Ccircle cx='98' cy='88' r='1'/%3E%3Ccircle cx='22' cy='78' r='1'/%3E%3C/g%3E%3C/svg%3E") repeat,
+        radial-gradient(1200px 500px at 50% -200px, rgba(46,139,87,.10), transparent 60%),
+        linear-gradient(180deg, #ffffff 0%, var(--bg) 100%);
+      min-height:100dvh;
+      -webkit-font-smoothing:antialiased;
+      -moz-osx-font-smoothing:grayscale;
+    }
+    @media (prefers-reduced-motion:no-preference){ :root{ scroll-behavior:smooth; } }
+    body.modal-open{ overflow:hidden; }
 
+    /* ========= Topbar ========= */
+    header#topbar{
+      position:sticky; top:0; z-index:30;
+      background:rgba(255,255,255,.86);
+      backdrop-filter:saturate(140%) blur(8px);
+      border-bottom:1px solid var(--line);
+    }
+    .tb{ max-width:1080px;margin:0 auto;padding:10px 16px;display:flex;align-items:center;justify-content:space-between;gap:12px; }
+    .brand{display:flex;align-items:center;gap:10px;font-weight:900;color:var(--brand-2)}
+    .brand-dot{width:10px;height:10px;border-radius:999px;background:linear-gradient(180deg,var(--brand),var(--accent))}
+    .tb-actions{display:flex;gap:8px;align-items:center;flex-wrap:wrap}
+    .badge-email{color:var(--muted);font-size:13px}
+
+    /* ========= Buttons & Inputs ========= */
+    .btn{ display:inline-flex;align-items:center;justify-content:center;gap:8px;padding:10px 14px;border-radius:12px;border:1px solid var(--line);background:#fff;color:var(--ink);font-weight:700;cursor:pointer;transition:transform .06s ease, box-shadow .18s ease, filter .18s ease; }
+    .btn:active{ transform:translateY(1px) }
+    .btn[disabled]{ opacity:.6; cursor:not-allowed }
+    .btn-primary{ border-color:transparent;background:var(--brand);color:#fff; }
+    .btn-primary:hover{ filter:brightness(.98) }
+    .btn-soft{ background:#f3f9f5;border-color:#dfe9e4 }
+    .btn-ghost{ background:transparent;border-color:transparent }
+    .btn.is-loading{ position:relative; pointer-events:none }
+    .btn.is-loading::after{ content:""; width:18px;height:18px; border:2px solid rgba(255,255,255,.7); border-top-color:transparent; border-radius:50%; display:inline-block; animation:spin .8s linear infinite }
+    @keyframes spin{ to{ transform:rotate(360deg) } }
+
+    label{ font-weight:700;font-size:13px; display:inline-block; margin-bottom:6px }
+    input{ width:100%;padding:12px 14px;border-radius:12px;border:1px solid var(--line);background:#fff;font-size:15px;outline:none;transition:box-shadow .18s,border .18s,transform .03s; }
+    input:focus{ border-color:var(--brand); box-shadow:0 0 0 3px var(--ring); }
+
+    /* ========= Layout / Cards ========= */
+    .wrap{ max-width:1080px; margin:0 auto; padding:0 16px 56px; }
+    .card{ background:var(--card);border:1px solid var(--line);border-radius:var(--radius);box-shadow:var(--shadow); padding:18px; }
+
+    /* ========= Hero (Guest / User) ========= */
+    .hero{ position:relative;overflow:hidden;color:#fff;text-align:center;background: linear-gradient(90deg, var(--brand-2), var(--brand)); }
+    .hero-pad{ padding: clamp(34px, 6.8vw, 84px) 16px 28px; }
+    .badge{ display:inline-block;padding:7px 10px;border-radius:999px;font-weight:800;letter-spacing:.06em;text-transform:uppercase;background:rgba(255,255,255,.20);font-size:12px }
+    h1.display{ margin:14px auto 8px;line-height:1.05;font-weight:900;font-size: clamp(28px, 5.2vw, 54px);text-shadow:0 8px 30px rgba(0,0,0,.18) }
+    .lead{ margin:8px auto 0; max-width:860px; font-size: clamp(14px, 2.4vw, 18px); opacity:.95 }
+
+    /* ========= Feature blocks ========= */
+    .features{ display:grid; gap:16px; margin-top:-24px }
+    @media (min-width:900px){ .features{ grid-template-columns:repeat(3,1fr) } }
+    .feat{ border-radius:14px; background:#fff; border:1px solid var(--line); box-shadow:var(--shadow); padding:16px }
+    .feat h3{ margin:0 0 6px; color:var(--brand); font-size:18px }
+    .feat p{ margin:0; color:var(--muted); font-size:14px }
+
+    /* ========= Auth / Grid ========= */
+    .grid-2{ display:grid; gap:18px; grid-template-columns:1fr }
+    @media (min-width:980px){ .grid-2{ grid-template-columns:1.1fr .9fr } }
+    h2{ margin:0 0 8px; font-size:22px; color:var(--brand-2) }
+    .muted{ color:var(--muted); font-size:13px }
+    .hide{ display:none !important }
+    .center{ text-align:center }
+
+    nav.tabs{ display:flex; gap:8px; flex-wrap:wrap; margin:10px 0 14px }
+    nav.tabs button{ border:none; background:#eef7f1; color:#175c3a; padding:8px 12px; border-radius:999px; font-weight:800; cursor:pointer }
+
+    /* ========= Modal ========= */
+    #profileModal{ position:fixed; inset:0; display:grid; place-items:center; background:rgba(16,32,25,.25); padding:16px; z-index:50 }
+    @media (prefers-reduced-motion:no-preference){
+      #profileModal .card{ animation:pop .16s ease-out }
+      @keyframes pop{ from{transform:translateY(8px) scale(.98); opacity:0} to{transform:none; opacity:1} }
+    }
+
+    .modal-card{ max-width:460px;width:100%;position:relative }
+
+    /* ========= Footer / helper spacing ========= */
+    .sp16{ height:16px } .sp24{ height:24px }
+    .visually-hidden{ position:absolute !important; height:1px; width:1px; overflow:hidden; clip:rect(1px, 1px, 1px, 1px); white-space:nowrap; }
+    .stack-10{ display:grid; gap:10px }
+    .stack-12{ display:grid; gap:12px }
+    .row{ display:flex; gap:10px; flex-wrap:wrap }


### PR DESCRIPTION
## Summary
- revert stylesheet to earlier brand colors and typography
- adjust HTML to load legacy fonts and theme color
- convert legacy test to modern Node test module

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bfd621131083269c2c34e660283dff